### PR TITLE
Fix Event startDate and endDate

### DIFF
--- a/seo.php
+++ b/seo.php
@@ -389,8 +389,8 @@ class seoPlugin extends Plugin
                       'priceCurrency' => @$event['event_offers_priceCurrency'],
                       'url' => @$event['event_offers_url'], 
                       ],
-                  'startDate' => @date("c", strtotime($event['event_startdate'])),
-                  'endDate' => @date("c", strtotime($event['event_enddate'])),
+                  'startDate' => @date("c", strtotime($event['event_startDate'])),
+                  'endDate' => @date("c", strtotime($event['event_endDate'])),
                   'description' => @$event['event_description'],
                   
                   ];


### PR DESCRIPTION
startDate and endDate of an event were always displayed as 1970-01-01 in the Google check, because of a typo in the index of `$event[]`

According to `blueprints/seo.yaml`, the header fields are `event_startDate`/`event_endDate` (camelCase).

I have not checked if there are other occurrences of this kind of error on different fields.