### PR TITLE
Fix for Facebook org: url not including language

### DIFF
--- a/seo.php
+++ b/seo.php
@@ -274,7 +274,7 @@ class seoPlugin extends Plugin
                 $meta['og:type']['content']         = 'article';
                // $meta['og:url']['name']             = 'og:url';
                 $meta['og:url']['property']         = 'og:url';
-                $meta['og:url']['content']          = $this->grav['uri']->url(true);
+                $meta['og:url']['content']          = $this->grav['page']->canonical(true);
             if (isset($page->header()->facebookdesc)) {
                 //$meta['og:description']['name']     = 'og:description';
                 $meta['og:description']['property'] = 'og:description';


### PR DESCRIPTION
Attempt to fix [https://github.com/paulmassen/grav-plugin-seo/issues/64](https://github.com/paulmassen/grav-plugin-seo/issues/64)

Another option is:
`$meta['og:url']['content'] = $this->grav['uri']->rooturl(true) . $this->grav['uri']->baseIncludingLanguage() . $this->grav['uri']->path();`

but just using the canonical url seems easier and should bring back the user's preferred page url.
