### PR TITLE
Keep Original Page Title for Template Use

### DIFF
--- a/seo.php
+++ b/seo.php
@@ -177,6 +177,7 @@ class seoPlugin extends Plugin
         $cleanedMarkdown = $this->cleanMarkdown($page->content());
        
         if (isset($page->header()->googletitle)) {
+            $page->header()->displaytitle = $page->header()->title;  // Keep original title available for template use
             $page->header()->title = $page->header()->googletitle;
         };
         if (isset($page->header()->googledesc)) {


### PR DESCRIPTION
Once the googletitle is set, there's no way for templates to access the original page title. There are many cases where the Google SEO title is too long and not suitable to display on the page as a title. This change creates a new displaytitle value to hold the original title before it's overwritten.